### PR TITLE
Ensure console commands return integers

### DIFF
--- a/Commands/WarmDeviceDetectorCache.php
+++ b/Commands/WarmDeviceDetectorCache.php
@@ -70,7 +70,7 @@ class WarmDeviceDetectorCache extends ConsoleCommand
 
         if (empty($numEntriesToCache)) {
             $output->writeln('No entries are supposed to be cached. Stopping command');
-            return;
+            return 0;
         }
 
         if (!file_exists($path)) {
@@ -128,7 +128,7 @@ class WarmDeviceDetectorCache extends ConsoleCommand
 
         if (empty($userAgents)) {
             $output->writeln('No user agents found');
-            return;
+            return 0;
         }
 
         $this->log($count . ' user agents found', $output);
@@ -176,6 +176,8 @@ class WarmDeviceDetectorCache extends ConsoleCommand
             CachedEntry::deleteLeastAccessedFiles($numEntriesToDelete);
             $output->writeln('done deleting files');
         }
+
+        return 0;
     }
 
 }


### PR DESCRIPTION
### Description:

Newer versions of symfony console will throw an error when a console command does not return an integer.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
