### PR TITLE
Adjustments for client hints support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,12 @@ env:
   matrix:
     - TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
     - TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik
-    - TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
 
 matrix:
   exclude:
     # execute latest stable tests only w/ PHP 5.6
     - php: 7.2
       env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_CORE=minimum_required_piwik
-    # execute UI tests only w/ PHP 5.6
-    - php: 7.4
-      env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
   include:
     - php: 8.0
       env: TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET SKIP_COMPOSER_INSTALL=1

--- a/Commands/WarmDeviceDetectorCache.php
+++ b/Commands/WarmDeviceDetectorCache.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
  * @link    https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+
 namespace Piwik\Plugins\DeviceDetectorCache\Commands;
 
 use Piwik\Container\StaticContainer;
@@ -56,7 +58,7 @@ class WarmDeviceDetectorCache extends ConsoleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $userAgents = array();
+        $userAgents = [];
 
         $regex = $this->config->getAccessLogRegex();
         $numEntriesToCache = $this->config->getNumEntriesToCache();
@@ -90,10 +92,12 @@ class WarmDeviceDetectorCache extends ConsoleCommand
                 if (empty($line)) {
                     continue;
                 }
-                preg_match($regex ,$line, $matches);
-                if (!empty($matches[$matchEntry])
+                preg_match($regex, $line, $matches);
+                if (
+                    !empty($matches[$matchEntry])
                     && strlen($matches[$matchEntry]) > 5
-                    && strlen($matches[$matchEntry]) < 700){
+                    && strlen($matches[$matchEntry]) < 700
+                ) {
                     $useragent = $matches[$matchEntry];
                     if (!isset($userAgents[$useragent])) {
                         $userAgents[$useragent] = 1;
@@ -105,8 +109,10 @@ class WarmDeviceDetectorCache extends ConsoleCommand
                         $userAgents[$useragent] = $userAgents[$useragent] + 1;
                     }
                 }
-                $line = null;unset($line);
-                $matches = null;unset($matches);
+                $line = null;
+                unset($line);
+                $matches = null;
+                unset($matches);
                 if ($numLinesProcessed % 10 === 0) {
                     usleep(300); // slightly slow down disk usage to avoid running eg into some EBS limit
                 }
@@ -155,16 +161,16 @@ class WarmDeviceDetectorCache extends ConsoleCommand
                 $this->printupdate('written files so far: ' . $i . ' detecting that many requests: ' . $numRequestsDetected, $output);
             }
             if ($i <= 10) {
-                $this->log('Found user agent '. $agent . ' count: '. $val, $output);
+                $this->log('Found user agent ' . $agent . ' count: ' . $val, $output);
             }
-            CachedEntry::writeToCache($agent);
+            CachedEntry::writeToCache($agent, []);
             // sleep 2ms to let CPU do something else
             // this will make things about 10m slower for 200K entries but at least sudden CPU increase for instance
             // can be prevented when there are only few CPUs available
             // note: roughly per minute we write around 5K entries
             usleep(2000);
         }
-        $output->writeln('Written '.$i.' cache entries to file.');
+        $output->writeln('Written ' . $i . ' cache entries to file.');
         $output->writeln('The hit ratio will be roughly ' . Piwik::getPercentageSafe($numRequestsDetected, $numLinesToProcess) . '%');
 
         $numCacheFilesExist = CachedEntry::getNumEntriesInCacheDir();
@@ -179,5 +185,4 @@ class WarmDeviceDetectorCache extends ConsoleCommand
 
         return 0;
     }
-
 }

--- a/Configuration.php
+++ b/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *

--- a/DeviceDetector/CachedBrowserParser.php
+++ b/DeviceDetector/CachedBrowserParser.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\DeviceDetectorCache\DeviceDetector;
+
+use DeviceDetector\Parser\Client\Browser;
+
+class CachedBrowserParser extends Browser
+{
+    protected $cachedUaResult = [];
+
+    public function setCachedResult($result)
+    {
+        $this->cachedUaResult = $result;
+    }
+
+    protected function parseBrowserFromUserAgent(): array
+    {
+        if (!empty($this->cachedUaResult)) {
+            return $this->cachedUaResult;
+        }
+
+        return parent::parseBrowserFromUserAgent();
+    }
+}

--- a/DeviceDetector/CachedOperatingSystemParser.php
+++ b/DeviceDetector/CachedOperatingSystemParser.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\DeviceDetectorCache\DeviceDetector;
+
+use DeviceDetector\Parser\OperatingSystem;
+
+class CachedOperatingSystemParser extends OperatingSystem
+{
+    protected $cachedUaResult = [];
+
+    public function setCachedResult($result)
+    {
+        $this->cachedUaResult = $result;
+    }
+
+    protected function parseOsFromUserAgent(): array
+    {
+        if (!empty($this->cachedUaResult)) {
+            return $this->cachedUaResult;
+        }
+
+        return parent::parseOsFromUserAgent();
+    }
+}

--- a/DeviceDetectorCache.php
+++ b/DeviceDetectorCache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -10,7 +11,6 @@ namespace Piwik\Plugins\DeviceDetectorCache;
 
 class DeviceDetectorCache extends \Piwik\Plugin
 {
-
     public function isTrackerPlugin()
     {
         return true;
@@ -21,5 +21,4 @@ class DeviceDetectorCache extends \Piwik\Plugin
         $config = new Configuration();
         $config->install();
     }
-
 }

--- a/Factory.php
+++ b/Factory.php
@@ -12,13 +12,13 @@ use Piwik\DeviceDetector\DeviceDetectorFactory;
 
 class Factory extends DeviceDetectorFactory
 {
-    protected function getDeviceDetectionInfo($userAgent)
+    protected function getDeviceDetectionInfo($userAgent, $clientHints = [])
     {
         $cache = CachedEntry::getCached($userAgent);
         if (!empty($cache)) {
-            return new CachedEntry($userAgent, $cache);
+            return new CachedEntry($userAgent, $clientHints, $cache);
         }
 
-        return parent::getDeviceDetectionInfo($userAgent);
+        return parent::getDeviceDetectionInfo($userAgent, $clientHints);
     }
 }

--- a/Factory.php
+++ b/Factory.php
@@ -12,7 +12,7 @@ use Piwik\DeviceDetector\DeviceDetectorFactory;
 
 class Factory extends DeviceDetectorFactory
 {
-    protected function getDeviceDetectionInfo($userAgent, $clientHints = [])
+    protected function getDeviceDetectionInfo($userAgent, array $clientHints = [])
     {
         $cache = CachedEntry::getCached($userAgent);
         if (!empty($cache)) {

--- a/config/config.php
+++ b/config/config.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'DeviceDetectorCacheIgnoreUserAgentsWithLessThanXRequests' => 9,
     'DeviceDetectorCacheNumLinesToScan' => 5000000,

--- a/config/test.php
+++ b/config/test.php
@@ -4,8 +4,8 @@ use Piwik\Plugins\DeviceDetectorCache\CachedEntry;
 
 return [
     'DeviceDetectorCacheIgnoreUserAgentsWithLessThanXRequests' => 0,
-    \Piwik\DeviceDetector\DeviceDetectorFactory::class => DI\decorate(function($previous) {
-        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT. '/tmp/devicecachetests/');
+    \Piwik\DeviceDetector\DeviceDetectorFactory::class => DI\decorate(function ($previous) {
+        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT . '/tmp/devicecachetests/');
 
         return $previous;
     })

--- a/config/tracker.php
+++ b/config/tracker.php
@@ -1,2 +1,3 @@
 <?php
+
 return [];

--- a/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -65,7 +66,7 @@ class SimpleFixtureTrackFewVisits extends Fixture
             ],
         ];
         //user agent 2 should detect an iphone even though it is not as it's read from cache
-        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT. '/tmp/devicecachetests/');
+        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT . '/tmp/devicecachetests/');
         DeviceDetectorCacheFactoryTest::writeFakeFile($expected, $this->userAgent2);
     }
 

--- a/tests/Integration/CachedEntryTest.php
+++ b/tests/Integration/CachedEntryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -17,7 +18,7 @@ class CachedEntryTest extends ConsoleCommandTestCase
     public function setUp(): void
     {
         parent::setUp();
-        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT. '/tmp/devicecachetests/');
+        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT . '/tmp/devicecachetests/');
         CachedEntry::clearCacheDir();
     }
 
@@ -35,27 +36,29 @@ class CachedEntryTest extends ConsoleCommandTestCase
 
     public function testGetNumCacheFiles()
     {
-        CachedEntry::writeToCache('foo');
+        CachedEntry::writeToCache('foo', []);
         $this->assertEquals(1, CachedEntry::getNumEntriesInCacheDir());
-        CachedEntry::writeToCache('bar');
+        CachedEntry::writeToCache('bar', []);
         $this->assertEquals(2, CachedEntry::getNumEntriesInCacheDir());
-        CachedEntry::writeToCache('baz');
+        CachedEntry::writeToCache('baz', []);
         $this->assertEquals(3, CachedEntry::getNumEntriesInCacheDir());
     }
 
     public function testGetCached_noEntry()
     {
-        $this->assertNull(CachedEntry::getCached('foo'));
+        $this->assertNull(CachedEntry::getCached('foo', []));
     }
 
     public function test_writeToCache_GetCached()
     {
-        CachedEntry::writeToCache('foo');
-        $cacheEntry = CachedEntry::getCached('foo');
-        $this->assertEquals(array(
+        CachedEntry::writeToCache('foo', []);
+        $cacheEntry = CachedEntry::getCached('foo', []);
+        $this->assertEquals(
+            [
             'bot', 'brand', 'client', 'device', 'model', 'os'
-        )
-        , array_keys($cacheEntry));
+            ],
+            array_keys($cacheEntry)
+        );
     }
 
     public function test_getCachePath()
@@ -80,7 +83,7 @@ class CachedEntryTest extends ConsoleCommandTestCase
 
     public function test_deleteLeastAccessedFiles_nothingToDelete()
     {
-        $filePath = CachedEntry::writeToCache('file');
+        $filePath = CachedEntry::writeToCache('file', []);
         $this->assertFileExists($filePath);
 
         CachedEntry::deleteLeastAccessedFiles(-1);
@@ -91,13 +94,13 @@ class CachedEntryTest extends ConsoleCommandTestCase
 
     public function test_deleteLeastAccessedFiles_deletesOnlyOldest()
     {
-        $filePath1 = CachedEntry::writeToCache('file');
+        $filePath1 = CachedEntry::writeToCache('file', []);
         sleep(1); // otherwise without sleep the sorting won't work properly
-        $filePath2 = CachedEntry::writeToCache('bar');
+        $filePath2 = CachedEntry::writeToCache('bar', []);
         sleep(1);
-        $filePath3 = CachedEntry::writeToCache('baz');
+        $filePath3 = CachedEntry::writeToCache('baz', []);
         sleep(1);
-        $filePath4 = CachedEntry::writeToCache('foo');
+        $filePath4 = CachedEntry::writeToCache('foo', []);
         sleep(1);
 
         CachedEntry::deleteLeastAccessedFiles(2);
@@ -110,13 +113,13 @@ class CachedEntryTest extends ConsoleCommandTestCase
 
     public function test_deleteLeastAccessedFiles_deletesOnlyOldest2()
     {
-        $filePath1 = CachedEntry::writeToCache('file');
+        $filePath1 = CachedEntry::writeToCache('file', []);
         sleep(1);
-        $filePath2 = CachedEntry::writeToCache('bar');
+        $filePath2 = CachedEntry::writeToCache('bar', []);
         sleep(1);
-        $filePath3 = CachedEntry::writeToCache('baz');
+        $filePath3 = CachedEntry::writeToCache('baz', []);
         sleep(1);
-        $filePath4 = CachedEntry::writeToCache('foo');
+        $filePath4 = CachedEntry::writeToCache('foo', []);
         sleep(1);
 
         touch($filePath1);
@@ -130,5 +133,4 @@ class CachedEntryTest extends ConsoleCommandTestCase
         $this->assertFileExists($filePath1);
         $this->assertFileExists($filePath3);
     }
-
 }

--- a/tests/Integration/CachedEntryTest.php
+++ b/tests/Integration/CachedEntryTest.php
@@ -13,6 +13,11 @@ use Piwik\Filesystem;
 use Piwik\Plugins\DeviceDetectorCache\CachedEntry;
 use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
 
+/**
+ * @group DeviceDetectorCache
+ * @group CachedEntryTest
+ * @group Plugins
+ */
 class CachedEntryTest extends ConsoleCommandTestCase
 {
     public function setUp(): void

--- a/tests/Integration/ConfigurationTest.php
+++ b/tests/Integration/ConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *

--- a/tests/Integration/WarmDeviceDetectorCacheTest.php
+++ b/tests/Integration/WarmDeviceDetectorCacheTest.php
@@ -16,6 +16,11 @@ use Piwik\Plugins\DeviceDetectorCache\Configuration;
 use Piwik\Plugins\DeviceDetectorCache\Factory;
 use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
 
+/**
+ * @group DeviceDetectorCache
+ * @group WarmDeviceDetectorCacheTest
+ * @group Plugins
+ */
 class WarmDeviceDetectorCacheTest extends ConsoleCommandTestCase
 {
     public function setUp(): void

--- a/tests/System/DeviceDetectorCacheTest.php
+++ b/tests/System/DeviceDetectorCacheTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -46,7 +47,7 @@ class DeviceDetectorCacheTest extends SystemTestCase
                 'periods'    => ['day'],
                 'testSuffix' => '',
                 // values have changes in Matomo 4.6, so ignore them as they are not relevant for this plugin anyways
-                'xmlFieldsToRemove' => array('timeSpent', 'timeSpentPretty')
+                'xmlFieldsToRemove' => ['timeSpent', 'timeSpentPretty']
             ],
         ];
 
@@ -62,7 +63,6 @@ class DeviceDetectorCacheTest extends SystemTestCase
     {
         return dirname(__FILE__);
     }
-
 }
 
 DeviceDetectorCacheTest::$fixture = new SimpleFixtureTrackFewVisits();

--- a/tests/Unit/DeviceDetectorCacheFactoryTest.php
+++ b/tests/Unit/DeviceDetectorCacheFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -19,7 +20,7 @@ class DeviceDetectorCacheFactoryTest extends TestCase
     public function setUp(): void
     {
         DeviceDetectorFactory::clearInstancesCache();
-        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT. '/tmp/devicecachetests/');
+        CachedEntry::setCacheDir(PIWIK_DOCUMENT_ROOT . '/tmp/devicecachetests/');
     }
 
     public function tearDown(): void
@@ -48,13 +49,83 @@ class DeviceDetectorCacheFactoryTest extends TestCase
         self::writeFakeFile($expected, $userAgent);
 
         $factory         = new Factory();
-        $deviceDetection = $factory->makeInstance($userAgent);
+        $deviceDetection = $factory->makeInstance($userAgent, []);
         $this->assertInstanceOf(CachedEntry::class, $deviceDetection);
         $this->assertEquals(null, $deviceDetection->getBot());
         $this->assertEquals('Cooper', $deviceDetection->getBrandName());
         $this->assertEquals($expected['client'], $deviceDetection->getClient());
         $this->assertEquals(1, $deviceDetection->getDevice());
         $this->assertEquals('iPhone', $deviceDetection->getModel());
+        $this->assertEquals($expected['os'], $deviceDetection->getOs());
+    }
+
+    public function testGetInstanceFromCacheWithClientHints()
+    {
+        $userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 Edg/97.0.1072.66";
+        $clientHints = [
+            'HTTP_SEC_CH_UA_PLATFORM' => '"Windows"',
+            'HTTP_SEC_CH_UA' => '" Not A;Brand";v="99", "Chromium";v="95", "Microsoft Edge";v="95"',
+            'HTTP_SEC_CH_UA_MOBILE' => "?0",
+            'HTTP_SEC_CH_UA_FULL_VERSION' => '"98.0.0.1"',
+            'HTTP_SEC_CH_UA_PLATFORM_VERSION' => '"14.0.0"',
+            'HTTP_SEC_CH_UA_ARCH' => "x86",
+            'HTTP_SEC_CH_UA_BITNESS' => "64",
+            'HTTP_SEC_CH_UA_MODEL' => ""
+        ];
+        $expected  = [
+            'bot'    => null,
+            'brand'  => '',
+            'client' => [
+                'type' => 'browser',
+                'name' => 'Microsoft Edge',
+                'version' => '97.0.1072.66'
+            ],
+            'device' => 1,
+            'model'  => '',
+            'os'     => [
+                'name' => 'Windows',
+                'version' => '10',
+            ],
+        ];
+
+        self::writeFakeFile($expected, $userAgent);
+
+        $factory         = new Factory();
+
+        // not using client hints will return the cached entry
+        $deviceDetection = $factory->makeInstance($userAgent, []);
+        $this->assertInstanceOf(CachedEntry::class, $deviceDetection);
+        $this->assertEquals(null, $deviceDetection->getBot());
+        $this->assertEquals($expected['brand'], $deviceDetection->getBrandName());
+        $this->assertEquals($expected['client'], $deviceDetection->getClient());
+        $this->assertEquals(1, $deviceDetection->getDevice());
+        $this->assertEquals($expected['model'], $deviceDetection->getModel());
+        $this->assertEquals($expected['os'], $deviceDetection->getOs());
+
+        // using client hints will overwrite some value if needed
+        $deviceDetection = $factory->makeInstance($userAgent, $clientHints);
+        $expected['os'] = [
+            'name' => 'Windows',
+            'version' => '11',
+            'short_name' => 'WIN',
+            'platform' => 'x64',
+            'family' => 'Windows',
+        ];
+        $expected['client'] = [
+            'type' => 'browser',
+            'name' => 'Microsoft Edge',
+            'version' => '98.0',
+            'short_name' => 'PS',
+            'engine' => 'Blink',
+            'engine_version' => '97.0.4692.71',
+            'family' => 'Internet Explorer',
+        ];
+        $this->assertInstanceOf(CachedEntry::class, $deviceDetection);
+        $this->assertEquals(null, $deviceDetection->getBot());
+        $this->assertEquals($expected['brand'], $deviceDetection->getBrandName());
+        $this->assertEquals($expected['client'], $deviceDetection->getClient());
+        $this->assertEquals(1, $deviceDetection->getDevice());
+        $this->assertEquals($expected['model'], $deviceDetection->getModel());
         $this->assertEquals($expected['os'], $deviceDetection->getOs());
     }
 
@@ -79,7 +150,7 @@ class DeviceDetectorCacheFactoryTest extends TestCase
         ];
 
         $factory         = new Factory();
-        $deviceDetection = $factory->makeInstance($userAgent);
+        $deviceDetection = $factory->makeInstance($userAgent, []);
         $this->assertInstanceOf("\DeviceDetector\DeviceDetector", $deviceDetection);
         $this->assertEquals(null, $deviceDetection->getBot());
         $this->assertEquals('AP', $deviceDetection->getBrand());

--- a/tests/Unit/DeviceDetectorCacheFactoryTest.php
+++ b/tests/Unit/DeviceDetectorCacheFactoryTest.php
@@ -15,6 +15,11 @@ use Piwik\Filesystem;
 use Piwik\Plugins\DeviceDetectorCache\CachedEntry;
 use Piwik\Plugins\DeviceDetectorCache\Factory;
 
+/**
+ * @group DeviceDetectorCache
+ * @group DeviceDetectorCacheFactoryTest
+ * @group Plugins
+ */
 class DeviceDetectorCacheFactoryTest extends TestCase
 {
     public function setUp(): void
@@ -90,7 +95,7 @@ class DeviceDetectorCacheFactoryTest extends TestCase
 
         self::writeFakeFile($expected, $userAgent);
 
-        $factory         = new Factory();
+        $factory = new Factory();
 
         // not using client hints will return the cached entry
         $deviceDetection = $factory->makeInstance($userAgent, []);


### PR DESCRIPTION
### Description:

With https://github.com/matomo-org/matomo/pull/18843 support for client hints will be introduced in Matomo.

As this plugin currently only caches based on the useragent, the additional client hint details would currently be lost.
On the other side it won't make sense to create cache entries based on the useragent and the client hints, as client hints won't be included in any log files.

So I've decided the extend the parser classes used for parsing browser and operating system. The cache entries are still stored based on the useragent. But if client hints are provided, the extended parsers will be used to enrich the results with the client hints.

As parsing the client hints is quite fast and still rarely sent at all, I don't think it's needed to included that in the caching.

Note: The changes in this PR should also work with Matomo versions nor using DeviceDetector with client hints. It therefor shouldn't be needed to increase the minimum required version.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
