### PR TITLE
Make sure to use a cached result when we have it so we wont detect it again

### DIFF
--- a/CachedEntry.php
+++ b/CachedEntry.php
@@ -39,11 +39,13 @@ class CachedEntry extends DeviceDetector
         // We use some special parsers, which use the cached user agent result and parses it again using client hints
         if (!empty($clientHints) && $values['client']['type'] === 'browser') {
             $browserParser = new CachedBrowserParser($userAgent, $clientHints);
+            $browserParser->setCachedResult($this->client);
             $this->client = $browserParser->parse();
         }
 
         if (!empty($clientHints)) {
             $osParser = new CachedOperatingSystemParser($userAgent, $clientHints);
+            $osParser->setCachedResult($this->os);
             $this->os = $osParser->parse();
         }
     }

--- a/tests/Unit/DeviceDetectorCacheFactoryTest.php
+++ b/tests/Unit/DeviceDetectorCacheFactoryTest.php
@@ -122,8 +122,9 @@ class DeviceDetectorCacheFactoryTest extends TestCase
             'name' => 'Microsoft Edge',
             'version' => '98.0',
             'short_name' => 'PS',
-            'engine' => 'Blink',
-            'engine_version' => '97.0.4692.71',
+            // empty because cached result doesn't contain it and engine won't be detected through client hints only
+            'engine' => '',
+            'engine_version' => '',
             'family' => 'Internet Explorer',
         ];
 


### PR DESCRIPTION
### Description:

The cache result methods were actually never called meaning it always tried to parse the user agent again.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
