### PR TITLE
Started using constants instead of hardcoded value for return

### DIFF
--- a/Commands/WarmDeviceDetectorCache.php
+++ b/Commands/WarmDeviceDetectorCache.php
@@ -72,7 +72,7 @@ class WarmDeviceDetectorCache extends ConsoleCommand
 
         if (empty($numEntriesToCache)) {
             $output->writeln('No entries are supposed to be cached. Stopping command');
-            return 0;
+            return self::SUCCESS;
         }
 
         if (!file_exists($path)) {
@@ -134,7 +134,7 @@ class WarmDeviceDetectorCache extends ConsoleCommand
 
         if (empty($userAgents)) {
             $output->writeln('No user agents found');
-            return 0;
+            return self::SUCCESS;
         }
 
         $this->log($count . ' user agents found', $output);
@@ -183,6 +183,6 @@ class WarmDeviceDetectorCache extends ConsoleCommand
             $output->writeln('done deleting files');
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
### Description:

Started using constants instead of hardcoded value for return.
Fixes: #PG-2642

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
