### PR TITLE
Fixes Uncaught TypeError on getDevice due to default being empty

### DIFF
--- a/CachedEntry.php
+++ b/CachedEntry.php
@@ -33,7 +33,7 @@ class CachedEntry extends DeviceDetector
         $this->client = $values['client'] ?? null;
         $this->device = $values['device'] ?? null;
         $this->model = $values['model'] ?? '';
-        $this->os = $values['os'] ?? '';
+        $this->os = $values['os'] ?? null;
 
         // Or cached entries only use the useragents, so if we have some client hints provided,
         // We use some special parsers, which use the cached user agent result and parses it again using client hints

--- a/CachedEntry.php
+++ b/CachedEntry.php
@@ -28,10 +28,10 @@ class CachedEntry extends DeviceDetector
         $clientHints = $clientHints ? ClientHints::factory($clientHints) : null;
         parent::__construct($userAgent, $clientHints);
 
-        $this->bot = $values['bot'] ?? '';
+        $this->bot = $values['bot'] ?? null;
         $this->brand = $values['brand'] ?? '';
-        $this->client = $values['client'] ?? '';
-        $this->device = $values['device'] ?? '';
+        $this->client = $values['client'] ?? null;
+        $this->device = $values['device'] ?? null;
         $this->model = $values['model'] ?? '';
         $this->os = $values['os'] ?? '';
 

--- a/tests/Integration/CachedEntryTest.php
+++ b/tests/Integration/CachedEntryTest.php
@@ -115,11 +115,46 @@ class CachedEntryTest extends ConsoleCommandTestCase
         $instance = new CachedEntry($userAgent, $clientHints, $values);
         $this->assertIsObject($instance);
         $this->assertInstanceOf(CachedEntry::class, $instance);
-        $this->assertSame('', $instance->getBot());
+        $this->assertSame(null, $instance->getBot());
         $this->assertSame($values['brand'], $instance->getBrandName());
         $this->assertSame($expectedClient, $instance->getClient());
         $this->assertSame($values['device'], $instance->getDevice());
         $this->assertSame($values['model'], $instance->getModel());
+        $this->assertSame($expectedOs, $instance->getOs());
+    }
+
+    public function testConstructDefault()
+    {
+        $userAgent = "unknown";
+
+        $clientHints = [
+            'HTTP_SEC_CH_UA_PLATFORM' => '"Windows"',
+            'HTTP_SEC_CH_UA' => '" Not A;Brand";v="99", "Chromium";v="95", "Microsoft Edge";v="95"',
+            'HTTP_SEC_CH_UA_MOBILE' => "?0",
+            'HTTP_SEC_CH_UA_FULL_VERSION' => '"98.0.0.1"',
+            'HTTP_SEC_CH_UA_PLATFORM_VERSION' => '"14.0.0"',
+            'HTTP_SEC_CH_UA_ARCH' => "x86",
+            'HTTP_SEC_CH_UA_BITNESS' => "64",
+            'HTTP_SEC_CH_UA_MODEL' => ""
+        ];
+
+        $expectedOs = [
+            'name' => 'Windows',
+            'short_name' => 'WIN',
+            'version' => '11',
+            'platform' => 'x64',
+            'family' => 'Windows',
+        ];
+
+
+        $instance = new CachedEntry($userAgent, $clientHints, []);
+        $this->assertIsObject($instance);
+        $this->assertInstanceOf(CachedEntry::class, $instance);
+        $this->assertSame(null, $instance->getBot());
+        $this->assertSame('', $instance->getBrandName());
+        $this->assertSame(null, $instance->getClient());
+        $this->assertSame(null, $instance->getDevice());
+        $this->assertSame('', $instance->getModel());
         $this->assertSame($expectedOs, $instance->getOs());
     }
 


### PR DESCRIPTION
### Description:

Fixes Uncaught TypeError on getDevice due to default being empty
Fixes: https://github.com/matomo-org/matomo/issues/21572

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
