### PR TITLE
DEV-20451: sync Live.getLastVisitsDetails fixture for accurate time-spent metric

### DIFF
--- a/tests/System/expected/test___Live.getLastVisitsDetails_day.xml
+++ b/tests/System/expected/test___Live.getLastVisitsDetails_day.xml
@@ -16,8 +16,8 @@
 				
 				<pageId>1</pageId>
 				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>360</timeSpent>
+				<timeSpentPretty>6 min 0s</timeSpentPretty>
 				<pageviewPosition>1</pageviewPosition>
 				<title>Viewing homepage</title>
 				<subtitle>http://example.com/sub/page</subtitle>

--- a/tests/System/expected/test___Live.getLastVisitsDetails_day.xml
+++ b/tests/System/expected/test___Live.getLastVisitsDetails_day.xml
@@ -16,8 +16,8 @@
 				
 				<pageId>1</pageId>
 				<bandwidth />
-				<timeSpent>721</timeSpent>
-				<timeSpentPretty>12 min 1s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<pageviewPosition>1</pageviewPosition>
 				<title>Viewing homepage</title>
 				<subtitle>http://example.com/sub/page</subtitle>


### PR DESCRIPTION
Companion submodule PR for [matomo-org/matomo#24788](https://github.com/matomo-org/matomo/pull/24788) — updates the checked-in expected fixture so it matches the new accurate per-pageview time-on-page output.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules